### PR TITLE
CIDR fixes and test improvements.

### DIFF
--- a/src/blacklist.c
+++ b/src/blacklist.c
@@ -67,7 +67,7 @@ int is_ip_blacklisted(redisContext *context, const char *actor, char *reason)
       char *block;
       for(i = 0; i < blacklist->elements; i++) {
         block = strtok(blacklist->element[i]->str, ":");
-        if (cidr_contains(block, actor)) {
+        if (cidr_contains(block, actor) > 0) {
           value = redisCommand(context, "GET %s:repsheet:cidr:blacklist", block);
           if (value) {
             populate_reason(value, reason);

--- a/src/cidr.c
+++ b/src/cidr.c
@@ -52,16 +52,25 @@ int cidr_contains(char *block, const char *address)
 int _string_to_cidr(CIDR *cidr, char *block)
 {
   char dup[strlen(block) + 1];
+  char *value;
   memcpy(dup, block, strlen(block) + 1);
 
-  cidr->address_string = strtok(dup,"/");
-  if (strlen(cidr->address_string) < 8 || strlen(cidr->address_string) > 16) {
-    return BAD_CIDR_BLOCK;
+  value = strtok(dup,"/");
+  if (value != NULL) {
+    cidr->address_string = value;
+    if (strlen(cidr->address_string) < 7 || strlen(cidr->address_string) > 16) {
+      return BAD_CIDR_BLOCK;
+    }
   }
 
-  cidr->mask = strtol(strtok(NULL,"/"), 0, 10);
-  if (cidr->mask < 0 || cidr->mask > 32) {
+  value = strtok(NULL,"/");
+  if (value == NULL) {
     return BAD_CIDR_BLOCK;
+  } else {
+    cidr->mask = strtol(value, 0, 10);
+    if (cidr->mask < 0 || cidr->mask > 32) {
+      return BAD_CIDR_BLOCK;
+    }
   }
 
   cidr->address = _string_to_integer(cidr->address_string);
@@ -75,14 +84,27 @@ int _string_to_cidr(CIDR *cidr, char *block)
 int _string_to_integer(const char *address)
 {
   char dup[strlen(address) + 1];
+  char *value;
   memcpy(dup, address, strlen(address) + 1);
 
-  int first, second, third, fourth;
+  int first, second, third, fourth = -1;
 
-  first = strtol(strtok(dup, "."), 0, 10);
-  second = strtol(strtok(NULL, "."), 0, 10);
-  third = strtol(strtok(NULL, "."), 0, 10);
-  fourth = strtol(strtok(NULL, "."), 0, 10);
+  value = strtok(dup, ".");
+  if (value != NULL) {
+    first = strtol(value, 0, 10);
+  }
+  value = strtok(NULL, ".");
+  if (value != NULL) {
+    second = strtol(value, 0, 10);
+  }
+  value = strtok(NULL, ".");
+  if (value != NULL) {
+    third = strtol(value, 0, 10);
+  }
+  value = strtok(NULL, ".");
+  if (value != NULL) {
+    fourth = strtol(value, 0, 10);
+  }
 
   int i;
   int octets[] = {first, second, third, fourth};

--- a/src/whitelist.c
+++ b/src/whitelist.c
@@ -67,7 +67,7 @@ int is_ip_whitelisted(redisContext *context, const char *actor, char *reason)
       char *block;
       for(i = 0; i < whitelist->elements; i++) {
         block = strtok(whitelist->element[i]->str, ":");
-        if (cidr_contains(block, actor)) {
+        if (cidr_contains(block, actor) > 0) {
           value = redisCommand(context, "GET %s:repsheet:cidr:whitelist", block);
           if (value) {
             populate_reason(value, reason);

--- a/test/blacklist_test.c
+++ b/test/blacklist_test.c
@@ -20,8 +20,10 @@ void blacklist_teardown(void)
   freeReplyObject(redisCommand(context, "flushdb"));
   if (reply) {
     freeReplyObject(reply);
+    reply=NULL;
   }
   redisFree(context);
+  context=NULL;
 }
 
 START_TEST(blacklist_ip_test)
@@ -90,10 +92,21 @@ START_TEST(is_ip_blacklisted_in_cidr_test)
 {
   char value[MAX_REASON_LENGTH];
 
-  redisCommand(context, "SET %s:repsheet:cidr:blacklist %s", "10.0.0.0/24", "CIDR Test");
+  redisCommand(context, "DEL %s:repsheet:cidr:blacklist", "0.0.0.1/32");
+
+  redisCommand(context, "SET %s:repsheet:cidr:blacklist %s", "10.0.0.0/24", "CIDR 24 Test");
   int response = is_ip_blacklisted(context, "10.0.0.15", value);
   ck_assert_int_eq(response, TRUE);
-  ck_assert_str_eq(value, "CIDR Test");
+  ck_assert_str_eq(value, "CIDR 24 Test");
+
+  redisCommand(context, "SET %s:repsheet:cidr:blacklist %s", "0.0.0.1/32", "CIDR 32 Test");
+  response = is_ip_blacklisted(context, "0.0.0.1", value);
+  ck_assert_int_eq(response, TRUE);
+  ck_assert_str_eq(value, "CIDR 32 Test");
+
+  // Verify a value not blacklisted does not match.
+  response = is_ip_blacklisted(context, "20.1.1.1", value);
+  ck_assert_int_eq(response, FALSE);
 }
 END_TEST
 

--- a/test/cidr_test.c
+++ b/test/cidr_test.c
@@ -17,16 +17,20 @@ END_TEST
 START_TEST(class_c_excludes)
 {
   char *block = "10.0.0.0/24";
+  char *bad_value = "foo";
   char *short_block = "0.0.0/24";
   char *bad_mask = "10.0.0.0/33";
+  char *no_mask = "10.0.0.0";
 
   char *in = "10.0.0.50";
   char *out = "10.0.1.50";
   char *too_large = "10.0.0.257";
   char *too_long = "10.0.0.1024";
 
+  ck_assert_int_eq(BAD_CIDR_BLOCK, cidr_contains(bad_value, in));
   ck_assert_int_eq(BAD_CIDR_BLOCK, cidr_contains(short_block, in));
   ck_assert_int_eq(BAD_CIDR_BLOCK, cidr_contains(bad_mask, in));
+  ck_assert_int_eq(BAD_CIDR_BLOCK, cidr_contains(no_mask, in));
 
   ck_assert_int_eq(0, cidr_contains(block, out));
   ck_assert_int_eq(BAD_ADDRESS, cidr_contains(block, too_large));

--- a/test/common_test.c
+++ b/test/common_test.c
@@ -20,8 +20,10 @@ void common_teardown(void)
   freeReplyObject(redisCommand(context, "flushdb"));
   if (reply) {
     freeReplyObject(reply);
+    reply=NULL;
   }
   redisFree(context);
+  context=NULL;
 }
 
 START_TEST(expire_test)

--- a/test/librepsheet_test.c
+++ b/test/librepsheet_test.c
@@ -21,8 +21,10 @@ void teardown(void)
   freeReplyObject(redisCommand(context, "flushdb"));
   if (reply) {
     freeReplyObject(reply);
+    reply=NULL;
   }
   redisFree(context);
+  context=NULL;
 }
 
 START_TEST(get_redis_context_failure_test)

--- a/test/marked_test.c
+++ b/test/marked_test.c
@@ -20,8 +20,10 @@ void marked_teardown(void)
   freeReplyObject(redisCommand(context, "flushdb"));
   if (reply) {
     freeReplyObject(reply);
+    reply=NULL;
   }
   redisFree(context);
+  context=NULL;
 }
 
 START_TEST(mark_ip_test)

--- a/test/recorder_test.c
+++ b/test/recorder_test.c
@@ -20,8 +20,10 @@ void recorder_teardown(void)
   freeReplyObject(redisCommand(context, "flushdb"));
   if (reply) {
     freeReplyObject(reply);
+    reply=NULL;
   }
   redisFree(context);
+  context=NULL;
 }
 
 START_TEST(record_test)


### PR DESCRIPTION
I found some bugs with librepsheet CIDR processing:

1) strtok processing was broken by passing NULL returns to strtol, causing crashes if the cidr value did not contain characters looked for like "/".
2) librepsheet considered a cidr IP address of less than 8 characters to be a bad value.  However, an IP like 1.1.1.1 only is 7 characters long, so now code fixed to check if less than 7 characters.
3) In src/blacklist.c and src/whitelist.c I changed "if (cidr_contains(block,actor))" to "if (cidr_contains(block,actor) > 0)".  Even though the error codes like BAD_ADDRESS BAD_CIDR_BLOCK are defined to be negative values, the test was passing as if the IP was contained when an IP returned these error codes.
4) I added tests that show these problems.  The test all now pass, but if you only apply the part of the patch in the test subdirectory you can see the failures on master.

In addition, I made a minor change to the various teardown functions in the tests directory to set the reply and context pointers to NULL after calling free() on them.  Otherwise the tests were crashing when I tried running them after setting the libcheck specific CK_FORK environment variable as follows:

export CK_FORK=no

This is useful to do when debugging test_running with gdb since it avoids forking and makes it easier to debug problems in the tests.
