### PR TITLE
Update repsheet keys to be more consistent

### DIFF
--- a/src/blacklist.c
+++ b/src/blacklist.c
@@ -27,13 +27,13 @@ int blacklist_actor(redisContext *context, const char *actor, int type, const ch
 
   switch(type) {
   case IP:
-    return set_list(context, actor, "ip", "blacklist", reason);
+    return set_list(context, actor, "ip", "blacklisted", reason);
     break;
   case USER:
-    return set_list(context, actor, "users", "blacklist", reason);
+    return set_list(context, actor, "users", "blacklisted", reason);
     break;
   case BLOCK:
-    return set_list(context, actor, "cidr", "blacklist", reason);
+    return set_list(context, actor, "cidr", "blacklisted", reason);
     break;
   default:
     return UNSUPPORTED;
@@ -52,7 +52,7 @@ int blacklist_actor(redisContext *context, const char *actor, int type, const ch
  */
 int is_ip_blacklisted(redisContext *context, const char *actor, char *reason)
 {
-  redisReply *ip = redisCommand(context, "GET %s:repsheet:ip:blacklist", actor);
+  redisReply *ip = redisCommand(context, "GET %s:repsheet:ip:blacklisted", actor);
   if (ip) {
     if (ip->type == REDIS_REPLY_STRING) {
       populate_reason(ip, reason);
@@ -65,7 +65,7 @@ int is_ip_blacklisted(redisContext *context, const char *actor, char *reason)
     return DISCONNECTED;
   }
 
-  redisReply *blacklist = redisCommand(context, "KEYS *:repsheet:cidr:blacklist");
+  redisReply *blacklist = redisCommand(context, "KEYS *:repsheet:cidr:blacklisted");
   if (blacklist) {
     if (blacklist->type == REDIS_REPLY_ARRAY) {
       int i;
@@ -74,7 +74,7 @@ int is_ip_blacklisted(redisContext *context, const char *actor, char *reason)
       for(i = 0; i < blacklist->elements; i++) {
         block = strtok(blacklist->element[i]->str, ":");
         if (cidr_contains(block, actor) > 0) {
-          value = redisCommand(context, "GET %s:repsheet:cidr:blacklist", block);
+          value = redisCommand(context, "GET %s:repsheet:cidr:blacklisted", block);
           if (value) {
             populate_reason(value, reason);
             freeReplyObject(value);
@@ -106,7 +106,7 @@ int is_user_blacklisted(redisContext *context, const char *actor, char *reason)
 {
   redisReply *reply;
 
-  reply = redisCommand(context, "GET %s:repsheet:users:blacklist", actor);
+  reply = redisCommand(context, "GET %s:repsheet:users:blacklisted", actor);
   if (reply) {
     if (reply->type == REDIS_REPLY_STRING) {
       populate_reason(reply, reason);
@@ -132,7 +132,7 @@ int is_user_blacklisted(redisContext *context, const char *actor, char *reason)
 int is_country_blacklisted(redisContext *context, const char *country_code)
 {
   redisReply *reply;
-  reply = redisCommand(context, "SISMEMBER repsheet:countries:blacklist %s", country_code);
+  reply = redisCommand(context, "SISMEMBER repsheet:countries:blacklisted %s", country_code);
   if (reply) {
     if (reply->type == REDIS_REPLY_INTEGER) {
       freeReplyObject(reply);
@@ -162,10 +162,10 @@ int is_historical_offender(redisContext *context, int type, const char *actor)
 
   switch(type) {
   case IP:
-    reply = redisCommand(context, "SISMEMBER repsheet:ip:blacklist:history %s", actor);
+    reply = redisCommand(context, "SISMEMBER repsheet:ip:blacklisted:history %s", actor);
     break;
   case USER:
-    reply = redisCommand(context, "SISMEMBER repsheet:user:blacklist:history %s", actor);
+    reply = redisCommand(context, "SISMEMBER repsheet:user:blacklisted:history %s", actor);
     break;
   default:
     return UNSUPPORTED;

--- a/src/common.c
+++ b/src/common.c
@@ -84,12 +84,12 @@ int blacklist_and_expire(redisContext *context, int type, const char *actor, int
   redisCommand(context, "MULTI");
   switch(type) {
   case IP:
-    redisCommand(context, "SETEX %s:repsheet:ip:blacklist %d %s", actor, expiry, reason);
-    redisCommand(context, "SADD repsheet:ip:blacklist:history %s", actor);
+    redisCommand(context, "SETEX %s:repsheet:ip:blacklisted %d %s", actor, expiry, reason);
+    redisCommand(context, "SADD repsheet:ip:blacklisted:history %s", actor);
     break;
   case USER:
-    redisCommand(context, "SETEX %s:repsheet:users:blacklist %d %s", actor, expiry, reason);
-    redisCommand(context, "SADD repsheet:users:blacklist:history %s", actor);
+    redisCommand(context, "SETEX %s:repsheet:users:blacklisted %d %s", actor, expiry, reason);
+    redisCommand(context, "SADD repsheet:users:blacklisted:history %s", actor);
     break;
   }
   reply = redisCommand(context, "EXEC");

--- a/src/marked.c
+++ b/src/marked.c
@@ -23,10 +23,10 @@ int mark_actor(redisContext *context, const char *actor, int type, const char *r
 
   switch(type) {
   case IP:
-    return set(context, actor, "ip", reason);
+    return set_list(context, actor, "ip", "marked", reason);
     break;
   case USER:
-    return set(context, actor, "users", reason);
+    return set_list(context, actor, "users", "marked", reason);
     break;
   default:
     return UNSUPPORTED;
@@ -47,7 +47,7 @@ int is_ip_marked(redisContext *context, const char *actor, char *reason)
 {
   redisReply *reply;
 
-  reply = redisCommand(context, "GET %s:repsheet:ip", actor);
+  reply = redisCommand(context, "GET %s:repsheet:ip:marked", actor);
   if (reply) {
     if (reply->type == REDIS_REPLY_STRING) {
       populate_reason(reply, reason);
@@ -75,7 +75,7 @@ int is_user_marked(redisContext *context, const char *actor, char *reason)
 {
   redisReply *reply;
 
-  reply = redisCommand(context, "GET %s:repsheet:users", actor);
+  reply = redisCommand(context, "GET %s:repsheet:users:marked", actor);
   if (reply) {
     if (reply->type == REDIS_REPLY_STRING) {
       populate_reason(reply, reason);

--- a/src/whitelist.c
+++ b/src/whitelist.c
@@ -27,13 +27,13 @@ int whitelist_actor(redisContext *context, const char *actor, int type, const ch
 
   switch(type) {
   case IP:
-    return set_list(context, actor, "ip", "whitelist", reason);
+    return set_list(context, actor, "ip", "whitelisted", reason);
     break;
   case USER:
-    return set_list(context, actor, "users", "whitelist", reason);
+    return set_list(context, actor, "users", "whitelisted", reason);
     break;
   case BLOCK:
-    return set_list(context, actor, "cidr", "whitelist", reason);
+    return set_list(context, actor, "cidr", "whitelisted", reason);
     break;
   default:
     return UNSUPPORTED;
@@ -52,7 +52,7 @@ int whitelist_actor(redisContext *context, const char *actor, int type, const ch
  */
 int is_ip_whitelisted(redisContext *context, const char *actor, char *reason)
 {
-  redisReply *ip = redisCommand(context, "GET %s:repsheet:ip:whitelist", actor);
+  redisReply *ip = redisCommand(context, "GET %s:repsheet:ip:whitelisted", actor);
   if (ip) {
     if (ip->type == REDIS_REPLY_STRING) {
       populate_reason(ip, reason);
@@ -65,7 +65,7 @@ int is_ip_whitelisted(redisContext *context, const char *actor, char *reason)
     return DISCONNECTED;
   }
 
-  redisReply *whitelist = redisCommand(context, "KEYS *:repsheet:cidr:whitelist");
+  redisReply *whitelist = redisCommand(context, "KEYS *:repsheet:cidr:whitelisted");
   if (whitelist) {
     if (whitelist->type == REDIS_REPLY_ARRAY) {
       int i;
@@ -74,7 +74,7 @@ int is_ip_whitelisted(redisContext *context, const char *actor, char *reason)
       for(i = 0; i < whitelist->elements; i++) {
         block = strtok(whitelist->element[i]->str, ":");
         if (cidr_contains(block, actor) > 0) {
-          value = redisCommand(context, "GET %s:repsheet:cidr:whitelist", block);
+          value = redisCommand(context, "GET %s:repsheet:cidr:whitelisted", block);
           if (value) {
             populate_reason(value, reason);
             freeReplyObject(value);
@@ -106,7 +106,7 @@ int is_user_whitelisted(redisContext *context, const char *actor, char *reason)
 {
   redisReply *reply;
 
-  reply = redisCommand(context, "GET %s:repsheet:users:whitelist", actor);
+  reply = redisCommand(context, "GET %s:repsheet:users:whitelisted", actor);
   if (reply) {
     if (reply->type == REDIS_REPLY_STRING) {
       populate_reason(reply, reason);
@@ -132,7 +132,7 @@ int is_user_whitelisted(redisContext *context, const char *actor, char *reason)
 int is_country_whitelisted(redisContext *context, const char *country_code)
 {
   redisReply *reply;
-  reply = redisCommand(context, "SISMEMBER repsheet:countries:whitelist %s", country_code);
+  reply = redisCommand(context, "SISMEMBER repsheet:countries:whitelisted %s", country_code);
   if (reply) {
     if (reply->type == REDIS_REPLY_INTEGER) {
       freeReplyObject(reply);

--- a/test/blacklist_test.c
+++ b/test/blacklist_test.c
@@ -30,7 +30,7 @@ START_TEST(blacklist_ip_test)
 {
   blacklist_actor(context, "1.1.1.1", IP, "IP Blacklist Actor Test");
 
-  reply = redisCommand(context, "GET 1.1.1.1:repsheet:ip:blacklist");
+  reply = redisCommand(context, "GET 1.1.1.1:repsheet:ip:blacklisted");
   ck_assert_str_eq(reply->str, "IP Blacklist Actor Test");
 }
 END_TEST
@@ -39,7 +39,7 @@ START_TEST(blacklist_user_test)
 {
   blacklist_actor(context, "repsheet", USER, "Users Blacklist Actor Test");
 
-  reply = redisCommand(context, "GET repsheet:repsheet:users:blacklist");
+  reply = redisCommand(context, "GET repsheet:repsheet:users:blacklisted");
   ck_assert_str_eq(reply->str, "Users Blacklist Actor Test");
 }
 END_TEST
@@ -48,7 +48,7 @@ START_TEST(blacklist_cidr_test)
 {
   blacklist_actor(context, "10.0.0.0/24", BLOCK, "Users Blacklist CIDR Test");
 
-  reply = redisCommand(context, "GET 10.0.0.0/24:repsheet:cidr:blacklist");
+  reply = redisCommand(context, "GET 10.0.0.0/24:repsheet:cidr:blacklisted");
   ck_assert_str_eq(reply->str, "Users Blacklist CIDR Test");
 }
 END_TEST
@@ -92,14 +92,14 @@ START_TEST(is_ip_blacklisted_in_cidr_test)
 {
   char value[MAX_REASON_LENGTH];
 
-  redisCommand(context, "DEL %s:repsheet:cidr:blacklist", "0.0.0.1/32");
+  redisCommand(context, "DEL %s:repsheet:cidr:blacklisted", "0.0.0.1/32");
 
-  redisCommand(context, "SET %s:repsheet:cidr:blacklist %s", "10.0.0.0/24", "CIDR 24 Test");
+  redisCommand(context, "SET %s:repsheet:cidr:blacklisted %s", "10.0.0.0/24", "CIDR 24 Test");
   int response = is_ip_blacklisted(context, "10.0.0.15", value);
   ck_assert_int_eq(response, TRUE);
   ck_assert_str_eq(value, "CIDR 24 Test");
 
-  redisCommand(context, "SET %s:repsheet:cidr:blacklist %s", "0.0.0.1/32", "CIDR 32 Test");
+  redisCommand(context, "SET %s:repsheet:cidr:blacklisted %s", "0.0.0.1/32", "CIDR 32 Test");
   response = is_ip_blacklisted(context, "0.0.0.1", value);
   ck_assert_int_eq(response, TRUE);
   ck_assert_str_eq(value, "CIDR 32 Test");
@@ -124,7 +124,7 @@ END_TEST
 
 START_TEST(is_historical_offender_ip_test)
 {
-  redisCommand(context, "SADD repsheet:ip:blacklist:history 1.1.1.1");
+  redisCommand(context, "SADD repsheet:ip:blacklisted:history 1.1.1.1");
   int response = is_historical_offender(context, IP, "1.1.1.1");
 
   ck_assert_int_eq(response, TRUE);
@@ -133,7 +133,7 @@ END_TEST
 
 START_TEST(is_not_historical_offender_ip_test)
 {
-  redisCommand(context, "SADD repsheet:ip:blacklist:history 1.1.1.2");
+  redisCommand(context, "SADD repsheet:ip:blacklisted:history 1.1.1.2");
   int response = is_historical_offender(context, IP, "1.1.1.1");
 
   ck_assert_int_eq(response, FALSE);
@@ -142,7 +142,7 @@ END_TEST
 
 START_TEST(is_historical_offender_user_test)
 {
-  redisCommand(context, "SADD repsheet:user:blacklist:history test");
+  redisCommand(context, "SADD repsheet:user:blacklisted:history test");
   int response = is_historical_offender(context, USER, "test");
 
   ck_assert_int_eq(response, TRUE);
@@ -165,14 +165,14 @@ END_TEST
 
 START_TEST(is_country_blacklisted_true_test)
 {
-  redisCommand(context, "SADD repsheet:countries:blacklist KP");
+  redisCommand(context, "SADD repsheet:countries:blacklisted KP");
   ck_assert_int_eq(is_country_blacklisted(context, "KP"), TRUE);
 }
 END_TEST
 
 START_TEST(country_status_blacklisted_test)
 {
-  redisCommand(context, "SADD repsheet:countries:blacklist KP");
+  redisCommand(context, "SADD repsheet:countries:blacklisted KP");
   ck_assert_int_eq(country_status(context, "KP"), BLACKLISTED);
 }
 END_TEST

--- a/test/common_test.c
+++ b/test/common_test.c
@@ -29,8 +29,8 @@ void common_teardown(void)
 START_TEST(expire_test)
 {
   mark_actor(context, "1.1.1.1", IP, "Expire Test");
-  expire(context, "1.1.1.1", "repsheet:ip", 200);
-  reply = redisCommand(context, "TTL 1.1.1.1:repsheet:ip");
+  expire(context, "1.1.1.1", "repsheet:ip:marked", 200);
+  reply = redisCommand(context, "TTL 1.1.1.1:repsheet:ip:marked");
 
   ck_assert_int_eq(reply->integer, 200);
 }
@@ -40,13 +40,13 @@ START_TEST(blacklist_and_expire_ip_test)
 {
   blacklist_and_expire(context, IP, "1.1.1.1", 200, "IP Blacklist And Expire Test");
 
-  reply = redisCommand(context, "TTL 1.1.1.1:repsheet:ip:blacklist");
+  reply = redisCommand(context, "TTL 1.1.1.1:repsheet:ip:blacklisted");
   ck_assert_int_eq(reply->integer, 200);
 
-  reply = redisCommand(context, "GET 1.1.1.1:repsheet:ip:blacklist");
+  reply = redisCommand(context, "GET 1.1.1.1:repsheet:ip:blacklisted");
   ck_assert_str_eq(reply->str, "IP Blacklist And Expire Test");
 
-  reply = redisCommand(context, "SISMEMBER repsheet:ip:blacklist:history 1.1.1.1");
+  reply = redisCommand(context, "SISMEMBER repsheet:ip:blacklisted:history 1.1.1.1");
   ck_assert_int_eq(reply->integer, 1);
 }
 END_TEST
@@ -55,13 +55,13 @@ START_TEST(blacklist_and_expire_user_test)
 {
   blacklist_and_expire(context, USER, "test", 200, "IP Blacklist And Expire Test");
 
-  reply = redisCommand(context, "TTL test:repsheet:users:blacklist");
+  reply = redisCommand(context, "TTL test:repsheet:users:blacklisted");
   ck_assert_int_eq(reply->integer, 200);
 
-  reply = redisCommand(context, "GET test:repsheet:users:blacklist");
+  reply = redisCommand(context, "GET test:repsheet:users:blacklisted");
   ck_assert_str_eq(reply->str, "IP Blacklist And Expire Test");
 
-  reply = redisCommand(context, "SISMEMBER repsheet:users:blacklist:history test");
+  reply = redisCommand(context, "SISMEMBER repsheet:users:blacklisted:history test");
   ck_assert_int_eq(reply->integer, 1);
 }
 END_TEST

--- a/test/librepsheet_test.c
+++ b/test/librepsheet_test.c
@@ -80,8 +80,8 @@ END_TEST
 START_TEST(country_status_test)
 {
   redisCommand(context, "SADD repsheet:countries:marked KP");
-  redisCommand(context, "SADD repsheet:countries:whitelist US");
-  redisCommand(context, "SADD repsheet:countries:blacklist AU");
+  redisCommand(context, "SADD repsheet:countries:whitelisted US");
+  redisCommand(context, "SADD repsheet:countries:blacklisted AU");
 
   ck_assert_int_eq(country_status(context, "KP"), MARKED);
   ck_assert_int_eq(country_status(context, "US"), WHITELISTED);

--- a/test/marked_test.c
+++ b/test/marked_test.c
@@ -30,7 +30,7 @@ START_TEST(mark_ip_test)
 {
   mark_actor(context, "1.1.1.1", IP, "IP Mark Actor Test");
 
-  reply = redisCommand(context, "GET 1.1.1.1:repsheet:ip");
+  reply = redisCommand(context, "GET 1.1.1.1:repsheet:ip:marked");
   ck_assert_str_eq(reply->str, "IP Mark Actor Test");
 }
 END_TEST
@@ -39,7 +39,7 @@ START_TEST(mark_user_test)
 {
   mark_actor(context, "repsheet", USER, "User Mark Actor Test");
 
-  reply = redisCommand(context, "GET repsheet:repsheet:users");
+  reply = redisCommand(context, "GET repsheet:repsheet:users:marked");
   ck_assert_str_eq(reply->str, "User Mark Actor Test");
 }
 END_TEST

--- a/test/whitelist_test.c
+++ b/test/whitelist_test.c
@@ -30,7 +30,7 @@ START_TEST(whitelist_ip_test)
 {
   whitelist_actor(context, "1.1.1.1", IP, "IP Whitelist Actor Test");
 
-  reply = redisCommand(context, "GET 1.1.1.1:repsheet:ip:whitelist");
+  reply = redisCommand(context, "GET 1.1.1.1:repsheet:ip:whitelisted");
   ck_assert_str_eq(reply->str, "IP Whitelist Actor Test");
 }
 END_TEST
@@ -39,7 +39,7 @@ START_TEST(whitelist_user_test)
 {
   whitelist_actor(context, "repsheet", USER, "User Whitelist Actor Test");
 
-  reply = redisCommand(context, "GET repsheet:repsheet:users:whitelist");
+  reply = redisCommand(context, "GET repsheet:repsheet:users:whitelisted");
   ck_assert_str_eq(reply->str, "User Whitelist Actor Test");
 }
 END_TEST
@@ -48,7 +48,7 @@ START_TEST(whitelist_cidr_test)
 {
   whitelist_actor(context, "10.0.0.0/24", BLOCK, "Users Whitelist CIDR Test");
 
-  reply = redisCommand(context, "GET 10.0.0.0/24:repsheet:cidr:whitelist");
+  reply = redisCommand(context, "GET 10.0.0.0/24:repsheet:cidr:whitelisted");
   ck_assert_str_eq(reply->str, "Users Whitelist CIDR Test");
 }
 END_TEST
@@ -69,14 +69,14 @@ START_TEST(is_ip_whitelisted_in_cidr_test)
 {
   char value[MAX_REASON_LENGTH];
 
-  redisCommand(context, "DEL %s:repsheet:cidr:whitelist", "0.0.0.1/32");
+  redisCommand(context, "DEL %s:repsheet:cidr:whitelisted", "0.0.0.1/32");
 
-  redisCommand(context, "SET %s:repsheet:cidr:whitelist %s", "10.0.0.0/24", "CIDR 24 Test");
+  redisCommand(context, "SET %s:repsheet:cidr:whitelisted %s", "10.0.0.0/24", "CIDR 24 Test");
   int response = is_ip_whitelisted(context, "10.0.0.15", value);
   ck_assert_int_eq(response, TRUE);
   ck_assert_str_eq(value, "CIDR 24 Test");
 
-  redisCommand(context, "SET %s:repsheet:cidr:whitelist %s", "0.0.0.1/32", "CIDR 32 Test");
+  redisCommand(context, "SET %s:repsheet:cidr:whitelisted %s", "0.0.0.1/32", "CIDR 32 Test");
   response = is_ip_whitelisted(context, "0.0.0.1", value);
   ck_assert_int_eq(response, TRUE);
   ck_assert_str_eq(value, "CIDR 32 Test");
@@ -101,7 +101,7 @@ END_TEST
 
 START_TEST(is_country_whitelisted_true_test)
 {
-  redisCommand(context, "SADD repsheet:countries:whitelist AU");
+  redisCommand(context, "SADD repsheet:countries:whitelisted AU");
   ck_assert_int_eq(is_country_whitelisted(context, "AU"), TRUE);
 }
 END_TEST
@@ -114,7 +114,7 @@ END_TEST
 
 START_TEST(country_status_whitelisted_test)
 {
-  redisCommand(context, "SADD repsheet:countries:whitelist AU");
+  redisCommand(context, "SADD repsheet:countries:whitelisted AU");
   ck_assert_int_eq(country_status(context, "AU"), WHITELISTED);
 }
 END_TEST


### PR DESCRIPTION
This change breaks the standard keyspaces for marked, blacklisted,
and whitelisted lookups. The new keyspace will be

```
<entry>:repsheet:<type>:blacklisted
<entry>:repsheet:<type>:whitelisted
<entry>:repsheet:<type>:marked