### PR TITLE
Reworked CIDR code 

### DIFF
--- a/src/cidr.c
+++ b/src/cidr.c
@@ -114,12 +114,12 @@ int ip_address_to_integer(const char *  address)
 {
   char tmp_string[MAX_BLOCK_ADDRESS_STRING_SIZE];
   char *cursor = tmp_string;
-  long octet[4];
+  long octets[4];
   int octet_number = 0;
 
   // make sure we're not overflowing any buffers
   strncpy(tmp_string, address, MAX_BLOCK_ADDRESS_STRING_SIZE);
-  dup[MAX_BLOCK_ADDRESS_STRING_SIZE - 1] = '\0';
+  tmp_string[MAX_BLOCK_ADDRESS_STRING_SIZE - 1] = '\0';
 
   // walk through the string parsing and verifying the octets one at a time
   while (octet_number < 4){

--- a/src/cidr.h
+++ b/src/cidr.h
@@ -3,11 +3,12 @@
 
 #define BAD_ADDRESS -3
 #define BAD_CIDR_BLOCK -4
+#define MAX_BLOCK_ADDRESS_STRING_SIZE 16
 
 typedef struct {
   int address;
   int mask;
-  char *address_string;
+  char address_string[MAX_BLOCK_ADDRESS_STRING_SIZE];
 } CIDR;
 
 #define MAX_BLOCK_SIZE 200

--- a/test/cidr_test.c
+++ b/test/cidr_test.c
@@ -23,17 +23,20 @@ START_TEST(class_c_excludes)
   char *short_block = "0.0.0/24";
   char *bad_mask = "10.0.0.0/33";
   char *no_mask = "10.0.0.0";
+  char *single_block = "222.222.222.222/32";
 
   int in = ip_address_to_integer("10.0.0.50");
   int out = ip_address_to_integer("10.0.1.50");
   int too_large = ip_address_to_integer("10.0.0.257");
   int too_long = ip_address_to_integer("10.0.0.1024");
+  int longest_out = ip_address_to_integer("222.222.222.223");
 
   ck_assert_int_eq(BAD_CIDR_BLOCK, cidr_contains(bad_value, in));
   ck_assert_int_eq(BAD_CIDR_BLOCK, cidr_contains(short_block, in));
   ck_assert_int_eq(BAD_CIDR_BLOCK, cidr_contains(bad_mask, in));
   ck_assert_int_eq(BAD_CIDR_BLOCK, cidr_contains(no_mask, in));
 
+  ck_assert_int_eq(0, cidr_contains(single_block, longest_out));
   ck_assert_int_eq(0, cidr_contains(block, out));
   ck_assert_int_eq(BAD_ADDRESS, cidr_contains(block, too_large));
   ck_assert_int_eq(BAD_ADDRESS, cidr_contains(block, too_long));


### PR DESCRIPTION
1) do not side effect pass by reference parameters when errors occur,
 2) do not use strtok because it isn't thread safe
 3) make CIDR.address_string a char[] instead of char*, so the struct doesn't point to memory it doesn't own and cannot free.

Updated tests with a new test for max v4 address length.